### PR TITLE
Fix WITH_DEVTOOLS: read environment variable instead of literal string #39

### DIFF
--- a/api/deno.json
+++ b/api/deno.json
@@ -5,7 +5,7 @@
     "@std/streams": "jsr:@std/streams@^1.1.1"
   },
   "name": "@01edu/api",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "license": "MIT",
   "exports": {
     "./context": "./context.ts",

--- a/api/env.ts
+++ b/api/env.ts
@@ -133,7 +133,7 @@ export const DEVTOOL_ACCESS_TOKEN: string = ENV('DEVTOOL_ACCESS_TOKEN', '')
  * }
  * ```
  */
-export const WITH_DEVTOOLS: boolean = truthy('WITH_DEVTOOLS')
+export const WITH_DEVTOOLS: boolean = truthy(ENV('WITH_DEVTOOLS', ''))
 
 /**
  * Disable query debug instrumentation when set in the environment.


### PR DESCRIPTION
fix(env): read WITH_DEVTOOLS environment variable instead of using a literal string