### PR TITLE
Do not send logs to devtools when devtools is not configured (skip send) #41

### DIFF
--- a/api/deno.json
+++ b/api/deno.json
@@ -5,7 +5,7 @@
     "@std/streams": "jsr:@std/streams@^1.1.1"
   },
   "name": "@01edu/api",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "license": "MIT",
   "exports": {
     "./context": "./context.ts",

--- a/api/log.ts
+++ b/api/log.ts
@@ -201,6 +201,7 @@ export const logger = async ({
   // DEVTOOLS Batch Logic
   async function flushLogs() {
     if (logBatch.length === 0) return
+    if (!logUrl || !logToken) return
 
     const batchToSend = logBatch
     logBatch = []
@@ -267,7 +268,7 @@ export const logger = async ({
   if (APP_ENV === 'dev') {
     return bind((level, event, props) => {
       if (f.has(event)) return
-      forwardLogsToDevtool(level, event, props)
+      ;(logUrl && logToken) && forwardLogsToDevtool(level, event, props)
       let callChain = ''
       for (const s of Error('').stack!.split('\n').slice(2).reverse()) {
         if (!s.includes(rootDir)) continue


### PR DESCRIPTION
fix(log): prevent sending logs to devtools when logUrl or logToken is not configured